### PR TITLE
Make devices -> clientConnectity -> mappingVariesByDestIP optional

### DIFF
--- a/src/tailscale/models.py
+++ b/src/tailscale/models.py
@@ -23,7 +23,9 @@ class ClientConnectivity(BaseModel):
 
     endpoints: List[str] = Field(default_factory=list)
     derp: str
-    mapping_varies_by_dest_ip: bool = Field(..., alias="mappingVariesByDestIP")
+    mapping_varies_by_dest_ip: Optional[bool] = Field(
+        None, alias="mappingVariesByDestIP"
+    )
     latency: Any
     client_supports: ClientSupports = Field(..., alias="clientSupports")
 


### PR DESCRIPTION
# Proposed Changes

Fixes this issue reported on the Home Assistant Discord in the #beta channel:

```txt
pydantic.error_wrappers.ValidationError: 1 validation error for Devices

devices -> xxxxx -> clientConnectivity -> mappingVariesByDestIP

  none is not an allowed value (type=type_error.none.not_allowed)
```