### PR TITLE
Device created datetime isn't always provided

### DIFF
--- a/src/tailscale/models.py
+++ b/src/tailscale/models.py
@@ -41,7 +41,7 @@ class Device(BaseModel):
     client_version: str = Field(..., alias="clientVersion")
     update_available: bool = Field(..., alias="updateAvailable")
     os: str
-    created: datetime
+    created: Optional[datetime]
     last_seen: Optional[datetime] = Field(..., alias="lastSeen")
     key_expiry_disabled: bool = Field(..., alias="keyExpiryDisabled")
     expires: Optional[datetime]


### PR DESCRIPTION
# Proposed Changes

Reported in, https://github.com/home-assistant/core/issues/61599.
Apparently the `created` value isn't always provided.
