### PR TITLE
Allow client supports to be none values

### DIFF
--- a/src/tailscale/models.py
+++ b/src/tailscale/models.py
@@ -11,11 +11,11 @@ class ClientSupports(BaseModel):
     """Object holding Tailscale device information."""
 
     hair_pinning: Optional[bool] = Field(..., alias="hairPinning")
-    ipv6: bool
-    pcp: bool
-    pmp: bool
-    udp: bool
-    upnp: bool
+    ipv6: Optional[bool]
+    pcp: Optional[bool]
+    pmp: Optional[bool]
+    udp: Optional[bool]
+    upnp: Optional[bool]
 
 
 class ClientConnectivity(BaseModel):


### PR DESCRIPTION
# Proposed Changes

Allow a bunch to be `None`. It seems at times the Tailscale API communicates `None` values for these.

## Related Issues

Ref: https://github.com/home-assistant/core/issues/63215
