### PR TITLE
Oauth support

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,4 @@
 [flake8]
 max-line-length = 88
 ignore = D202
-per-file-ignores = tests/*:DAR,S101
+per-file-ignores = tests/*:DAR,S101,S106

--- a/examples/devices.py
+++ b/examples/devices.py
@@ -2,15 +2,23 @@
 """Asynchronous client for the Tailscale API."""
 
 import asyncio
+import os
 
 from tailscale import Tailscale
+
+API_KEY = os.environ.get("TS_API_KEY", "tskey-somethingsomething")
+TAILNET = os.environ.get("TS_TAILNET", "-")  # "-" is the default tailnet of the API key
+OAUTH_CLIENT_ID = os.environ.get("TS_API_CLIENT_ID", "")
+OAUTH_CLIENT_SECRET = os.environ.get("TS_API_CLIENT_SECRET", "")
 
 
 async def main() -> None:
     """Show example on using the Tailscale API client."""
     async with Tailscale(
-        tailnet="frenck",
-        api_key="tskey-somethingsomething",
+        tailnet=TAILNET,
+        api_key=API_KEY,
+        oauth_client_id=OAUTH_CLIENT_ID,
+        oauth_client_secret=OAUTH_CLIENT_SECRET,
     ) as tailscale:
 
         devices = await tailscale.devices()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tailscale"
-version = "0.0.0"
+version = "0.4.0"
 description = "Asynchronous client for the Tailscale API."
 authors = ["Franck Nijhof <opensource@frenck.dev>"]
 maintainers = ["Franck Nijhof <opensource@frenck.dev>"]
@@ -154,6 +154,7 @@ ignore-imports = true
 
 [tool.pylint.FORMAT]
 max-line-length=88
+
 
 [tool.pytest.ini_options]
 addopts = "--cov"

--- a/src/tailscale/tailscale.py
+++ b/src/tailscale/tailscale.py
@@ -5,12 +5,12 @@ import asyncio
 import socket
 from dataclasses import dataclass
 from importlib import metadata
-from typing import Any
+from typing import Any, Dict
 
 import async_timeout
 from aiohttp import BasicAuth
 from aiohttp.client import ClientError, ClientResponseError, ClientSession
-from aiohttp.hdrs import METH_GET
+from aiohttp.hdrs import METH_DELETE, METH_GET, METH_POST
 from yarl import URL
 
 from .exceptions import (
@@ -25,13 +25,122 @@ from .models import Device, Devices
 class Tailscale:
     """Main class for handling connections with the Tailscale API."""
 
-    tailnet: str
-    api_key: str
+    api_key: str = ""  # nosec
+    # '-' used in a URI will assume default tailnet of api key
+    tailnet: str = "-"
+    oauth_client_id: str = ""  # nosec
+    oauth_client_secret: str = ""  # nosec
 
     request_timeout: int = 8
     session: ClientSession | None = None
 
     _close_session: bool = False
+
+    async def _check_access(self) -> None:
+        """Initialize the Tailscale client.
+
+        Raises:
+            TailscaleAuthenticationError: when neither api_key nor oauth_client_id and
+                oauth_client_secret are provided.
+        """
+        if (
+            not self.api_key  # noqa: W503
+            and not self.oauth_client_id  # noqa: W503
+            and not self.oauth_client_secret  # noqa: W503
+        ):
+            raise TailscaleAuthenticationError(
+                "Either api_key or (oauth_client_id and ",
+                "oauth_client_secret) is required",
+            )
+        if not self.api_key:
+            # set the api_key to a placeholder value so that the
+            # _get_oauth_token method can set it to the actual value
+            self.api_key = "pending"  # nosec
+            self.api_key = await self._get_oauth_token()
+
+    async def _get_oauth_token(self) -> str:
+        """Get an OAuth token from the Tailscale API.
+
+        Raises:
+            TailscaleAuthenticationError: when access key not found in response.
+
+        Returns:
+            A string with the OAuth token, or nothing on error
+
+        """
+        data = {
+            "client_id": self.oauth_client_id,
+            "client_secret": self.oauth_client_secret,
+        }
+        response = await self._get("oauth/token", data=data, use_auth_key=False)
+
+        token = response.get("access_token", "")
+        if not token:
+            raise TailscaleAuthenticationError("Failed to get OAuth token")
+        return str(token)
+
+    async def _post(
+        self,
+        uri: str,
+        *,
+        data: dict[str, Any] | None = None,
+        use_auth_key: bool = True,
+    ) -> dict[str, Any]:
+        """Make a POST request to the Tailscale API.
+
+        Args:
+            uri: Request URI, without '/api/v2/'.
+            data: Dictionary of data to send to the Tailscale API.
+            use_auth_key: Whether to use the API key or not.
+
+        Returns:
+            A Python dictionary (JSON decoded) with the response from
+            the Tailscale API.
+
+        """
+        return await self._request(
+            uri, method=METH_POST, data=data, use_auth_key=use_auth_key
+        )
+
+    async def _delete(
+        self,
+        uri: str,
+        *,
+        data: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Make a DELETE request to the Tailscale API.
+
+        Args:
+            uri: Request URI, without '/api/v2/'.
+            data: Dictionary of data to send to the Tailscale API.
+
+        Returns:
+            A Python dictionary (JSON decoded) with the response from
+            the Tailscale API.
+        """
+        return await self._request(uri, method=METH_DELETE, data=data)
+
+    async def _get(
+        self,
+        uri: str,
+        *,
+        data: dict[str, Any] | None = None,
+        use_auth_key: bool = True,
+    ) -> dict[str, Any]:
+        """Make a GET request to the Tailscale API.
+
+        Args:
+            uri: Request URI, without '/api/v2/'.
+            data: Dictionary of data to send to the Tailscale API.
+            use_auth_key: Whether to use the API key or not.
+
+        Returns:
+            A Python dictionary (JSON decoded) with the response from
+            the Tailscale API.
+        """
+        return await self._request(
+            uri, method=METH_GET, data=data, use_auth_key=use_auth_key
+        )
 
     async def _request(
         self,
@@ -39,6 +148,7 @@ class Tailscale:
         *,
         method: str = METH_GET,
         data: dict[str, Any] | None = None,
+        use_auth_key: bool = True,
     ) -> dict[str, Any]:
         """Handle a request to the Tailscale API.
 
@@ -49,6 +159,7 @@ class Tailscale:
             uri: Request URI, without '/api/v2/'.
             method: HTTP Method to use.
             data: Dictionary of data to send to the Tailscale API.
+            use_auth_key: Whether to use the API key or not.
 
         Returns:
             A Python dictionary (JSON decoded) with the response from
@@ -72,14 +183,16 @@ class Tailscale:
         if self.session is None:
             self.session = ClientSession()
             self._close_session = True
+        await self._check_access()
 
         try:
             async with async_timeout.timeout(self.request_timeout):
+                auth = BasicAuth(self.api_key) if use_auth_key else None
                 response = await self.session.request(
                     method,
                     url,
                     json=data,
-                    auth=BasicAuth(self.api_key),
+                    auth=auth,
                     headers=headers,
                 )
                 response.raise_for_status()
@@ -93,9 +206,12 @@ class Tailscale:
                     "Authentication to the Tailscale API failed"
                 ) from exception
             raise TailscaleError(
-                "Error occurred while connecting to the Tailscale API"
+                "Error occurred while connecting to the Tailscale API: ",
+                f"{exception.message}",
             ) from exception
         except (
+            # raise_for_status always raises a ClientResponseError,
+            # not sure this will be hit
             ClientError,
             socket.gaierror,
         ) as exception:
@@ -103,16 +219,16 @@ class Tailscale:
                 "Error occurred while communicating with the Tailscale API"
             ) from exception
 
-        response_data: dict[str, Any] = await response.json(content_type=None)
+        response_data: Dict[str, Any] = await response.json(content_type=None)
         return response_data
 
-    async def devices(self) -> dict[str, Device]:
+    async def devices(self) -> Dict[str, Device]:
         """Get devices information from the Tailscale API.
 
         Returns:
             Returns a dictionary of Tailscale devices.
         """
-        data = await self._request(f"tailnet/{self.tailnet}/devices?fields=all")
+        data = await self._get(f"tailnet/{self.tailnet}/devices?fields=all")
         return Devices.parse_obj(data).devices
 
     async def close(self) -> None:

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -1,0 +1,113 @@
+"""Asynchronous client for the Tailscale API."""
+# pylint: disable=protected-access
+# pyright: reportGeneralTypeIssues=false
+import json
+from typing import Dict
+
+import aiohttp
+import pytest
+from aresponses import ResponsesMockServer
+
+from tailscale import Tailscale
+
+test_device_1 = {
+    "addresses": ["100.71.74.78", "fd7a:115c:a1e0:ac82:4843:ca90:697d:c36e"],
+    "id": "test",
+    "user": "amelie@example.com",
+    "name": "pangolin.tailfe8c.ts.net",
+    "hostname": "pangolin",
+    "clientVersion": "",
+    "updateAvailable": False,
+    "os": "linux",
+    "created": "2022-12-01T05:23:30Z",
+    "lastSeen": "2022-12-01T05:23:30Z",
+    "keyExpiryDisabled": True,
+    "expires": "2023-07-30T04:44:05Z",
+    "authorized": True,
+    "isExternal": False,
+    "machineKey": "test",
+    "nodeKey": "nodekey:01234567890abcdef",
+    "blocksIncomingConnections": False,
+    "enabledRoutes": [
+        "10.0.0.0/16",
+        "192.168.1.0/24",
+    ],
+    "advertisedRoutes": [
+        "10.0.0.0/16",
+        "192.168.1.0/24",
+    ],
+    "clientConnectivity": {
+        "endpoints": ["199.9.14.201:59128", "192.68.0.21:59128"],
+        "derp": "1.1.1.1:8080",
+        "mappingVariesByDestIP": False,
+        "latency": {
+            "Dallas": {"latencyMs": 60.463043},
+            "New York City": {"preferred": True, "latencyMs": 31.323811},
+        },
+        "clientSupports": {
+            "hairPinning": False,
+            "ipv6": False,
+            "pcp": False,
+            "pmp": False,
+            "udp": True,
+            "upnp": False,
+        },
+    },
+    "tags": ["tag:golink"],
+    "tailnetLockError": "",
+    "tailnetLockKey": "",
+}
+test_device_2 = {
+    "addresses": ["100.71.70.69", "fd7a:115c:a1e0:ac82:4843:ca90:697d:c36e"],
+    "id": "testing",
+    "user": "pangolin@example.com",
+    "name": "bat.tailfe8c.ts.net",
+    "hostname": "bat",
+    "clientVersion": "",
+    "updateAvailable": False,
+    "os": "linux",
+    "created": "",
+    "lastSeen": "2022-12-01T05:23:30Z",
+    "tags": ["tag:golink"],
+    "keyExpiryDisabled": True,
+    "expires": "2023-07-30T04:44:05Z",
+    "authorized": True,
+    "isExternal": False,
+    "machineKey": "test",
+    "nodeKey": "nodekey:01234567890abcdef",
+    "blocksIncomingConnections": False,
+    "clientConnectivity": {
+        "derp": "",
+        "clientSupports": {
+            "hairPinning": False,
+        },
+    },
+}
+example_devices = {
+    "devices": [
+        test_device_1,
+        test_device_2,
+    ]
+}
+
+
+@pytest.mark.asyncio
+async def test_devices(aresponses: ResponsesMockServer) -> None:
+    """Tests getting all devices."""
+    aresponses.add(
+        "api.tailscale.com",
+        "/api/v2/tailnet/frenck/devices",
+        "GET",
+        aresponses.Response(
+            status=200,
+            headers={"Content-Type": "application/json"},
+            text=json.dumps(example_devices),
+        ),
+    )
+
+    async with aiohttp.ClientSession() as session:
+        tailscale = Tailscale(tailnet="frenck", api_key="abc", session=session)
+        devices = await tailscale.devices()
+        assert isinstance(devices, Dict)
+        assert devices["test"].device_id == "test"
+        assert devices["testing"].device_id == "testing"


### PR DESCRIPTION
# Proposed Changes

Adding support for oauth client authentication. See [Tailscale docs](https://tailscale.com/kb/1215/oauth-clients/)

Probably wanna squash this merge, it has commits from my original PR  #352
