### PR TITLE
Allow setting a custom tailscale API URL

### DIFF
--- a/src/tailscale/tailscale.py
+++ b/src/tailscale/tailscale.py
@@ -29,6 +29,7 @@ class Tailscale:
 
     request_timeout: int = 8
     session: ClientSession | None = None
+    api_url: str = "https://api.tailscale.com"
 
     _close_session: bool = False
 
@@ -64,7 +65,7 @@ class Tailscale:
                 API.
 
         """
-        url = URL("https://api.tailscale.com/api/v2/").join(URL(uri))
+        url = URL(self.api_url).join(URL("/api/v2/")).join(URL(uri))
 
         headers = {
             "Accept": "application/json",

--- a/tests/test_tailscale.py
+++ b/tests/test_tailscale.py
@@ -123,3 +123,20 @@ async def test_http_error401(aresponses: ResponsesMockServer) -> None:
         tailscale = Tailscale(tailnet="frenck", api_key="abc", session=session)
         with pytest.raises(TailscaleAuthenticationError):
             assert await tailscale._request("test")
+
+
+async def test_alternative_url(aresponses: ResponsesMockServer) -> None:
+    """Test alternative URL is handled correctly."""
+    aresponses.add(
+        "tailscale.example.com",
+        "/api/v2/test",
+        "GET",
+        aresponses.Response(
+            status=200,
+            headers={"Content-Type": "application/json"},
+            text='{"status": "ok"}',
+        ),
+    )
+    async with Tailscale(tailnet="frenck", api_key="abc", api_url="https://tailscale.example.com") as tailscale:
+        response = await tailscale._request("test")
+        assert response == '{"status": "ok"}'


### PR DESCRIPTION
New optional parameter for `Tailscale()`: `api_url`, same as `--login-server` for the `tailscale` CLI client.

# Proposed Changes

This change will allow setting a custom API URL for the tailscale control server. One other implementation which can be self-hosted is https://github.com/juanfont/headscale

It does this by introducing a new parameter for the `Tailscale` constructor, which just defaults to the official tailscale API server.