### PR TITLE
Make client connectivity optional

### DIFF
--- a/src/tailscale/models.py
+++ b/src/tailscale/models.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import Any
+from typing import Any, Optional
 
 from mashumaro import field_options
 from mashumaro.mixins.orjson import DataClassORJSONMixin
@@ -46,7 +46,7 @@ class Device(DataClassORJSONMixin):
     blocks_incoming_connections: bool = field(
         metadata=field_options(alias="blocksIncomingConnections")
     )
-    client_connectivity: ClientConnectivity = field(
+    client_connectivity: Optional[ClientConnectivity] = field(
         metadata=field_options(alias="clientConnectivity")
     )
     client_version: str = field(metadata=field_options(alias="clientVersion"))

--- a/src/tailscale/models.py
+++ b/src/tailscale/models.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import Any, Optional
+from typing import Any
 
 from mashumaro import field_options
 from mashumaro.mixins.orjson import DataClassORJSONMixin
@@ -46,7 +46,7 @@ class Device(DataClassORJSONMixin):
     blocks_incoming_connections: bool = field(
         metadata=field_options(alias="blocksIncomingConnections")
     )
-    client_connectivity: Optional[ClientConnectivity] = field(
+    client_connectivity: ClientConnectivity | None = field(
         metadata=field_options(alias="clientConnectivity")
     )
     client_version: str = field(metadata=field_options(alias="clientVersion"))


### PR DESCRIPTION
# Proposed Changes

Make the ClientConnectivity section of the Device DataClassORJSONMixin optional to resolve the kinds of  issues seen in #1016.

```
  File "/home/user/github/python-tailscale/src/tailscale/tailscale.py", line 114, in devices
    return Devices.from_json(data).devices
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "<string>", line 12, in __mashumaro_from_json__
mashumaro.exceptions.InvalidFieldValue: Field "devices" of type dict[str, Device] in Devices has invalid value {<all the stuff in my tailnet>}
```

When I make these changes, this error goes away and I am then able to get my list of tailscale devices again.

## Related Issues

fixes #1016 

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
