### PR TITLE
Set lastSeen to now if missing in API response

### DIFF
--- a/src/tailscale/models.py
+++ b/src/tailscale/models.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any
 
 from mashumaro import field_options
@@ -87,6 +87,11 @@ class Device(DataClassORJSONMixin):
         # Convert an empty string to None.
         if not d.get("created"):
             d["created"] = None
+
+        # Set lastSeen to now if not present in API response.
+        if not d.get("lastSeen"):
+            d["lastSeen"] = datetime.now(tz=timezone.utc).isoformat()
+
         return d
 
 


### PR DESCRIPTION
# Proposed Changes

The Home Assistant integration is currently failing to setup and if I nailed it correctly, the model does not match the API anymore. lastSeen is not in the API response, if the device is currently connected to the tailnet. I think, it restores the old behavior, if we set lastSeen to now in that case. However, I'm not sure if that is the best possible solution.

## Related Issues

> https://github.com/home-assistant/core/issues/154111

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
