### PR TITLE
OAuth support

### DIFF
--- a/examples/oauth.py
+++ b/examples/oauth.py
@@ -1,0 +1,29 @@
+"""Asynchronous Python client for the Tailscale API."""
+
+import asyncio
+import os
+
+from tailscale import Tailscale
+
+TAILNET = os.environ.get("TS_TAILNET", "-")
+OAUTH_CLIENT_ID = os.environ.get("TS_API_CLIENT_ID", "")
+OAUTH_CLIENT_SECRET = os.environ.get("TS_API_CLIENT_SECRET", "")
+
+
+async def main() -> None:
+    """Show example of using the Tailscale API client with OAuth."""
+    async with Tailscale(
+        tailnet=TAILNET,
+        oauth_client_id=OAUTH_CLIENT_ID,
+        oauth_client_secret=OAUTH_CLIENT_SECRET,
+    ) as tailscale:
+        devices = await tailscale.devices()
+
+        for device_id, device in devices.items():
+            print(f"{device.hostname} ({device.os})")
+            print(f"  ID: {device_id}")
+            print(f"  Addresses: {', '.join(device.addresses)}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/src/tailscale/__init__.py
+++ b/src/tailscale/__init__.py
@@ -6,6 +6,7 @@ from .exceptions import (
     TailscaleError,
 )
 from .models import ClientConnectivity, ClientSupports, Device, Devices, Latency
+from .storage import TokenStorage
 from .tailscale import Tailscale
 
 __all__ = [
@@ -18,4 +19,5 @@ __all__ = [
     "TailscaleAuthenticationError",
     "TailscaleConnectionError",
     "TailscaleError",
+    "TokenStorage",
 ]

--- a/src/tailscale/storage.py
+++ b/src/tailscale/storage.py
@@ -1,0 +1,29 @@
+"""Abstract token storage for the Tailscale API."""
+
+from abc import ABC, abstractmethod
+from datetime import datetime
+
+
+class TokenStorage(ABC):
+    """Abstract class for token storage implementations."""
+
+    @abstractmethod
+    async def get_token(self) -> tuple[str, datetime] | None:
+        """Get the stored token.
+
+        Returns
+        -------
+            The stored token and expiration time, or None if no token is stored.
+
+        """
+
+    @abstractmethod
+    async def set_token(self, access_token: str, expires_at: datetime) -> None:
+        """Store the given token.
+
+        Args:
+        ----
+            access_token: The access token to store.
+            expires_at: The expiration time of the access token.
+
+        """

--- a/src/tailscale/tailscale.py
+++ b/src/tailscale/tailscale.py
@@ -5,11 +5,12 @@ from __future__ import annotations
 import asyncio
 import socket
 from dataclasses import dataclass
-from typing import Any, Self
+from datetime import UTC, datetime, timedelta
+from typing import TYPE_CHECKING, Any, Self
 
-from aiohttp import BasicAuth
+import orjson
 from aiohttp.client import ClientError, ClientResponseError, ClientSession
-from aiohttp.hdrs import METH_GET
+from aiohttp.hdrs import METH_GET, METH_POST
 from yarl import URL
 
 from .exceptions import (
@@ -19,18 +20,126 @@ from .exceptions import (
 )
 from .models import Device, Devices
 
+if TYPE_CHECKING:
+    from .storage import TokenStorage
+
 
 @dataclass
+# pylint: disable-next=too-many-instance-attributes
 class Tailscale:
     """Main class for handling connections with the Tailscale API."""
 
-    tailnet: str
-    api_key: str
+    tailnet: str = "-"
+    api_key: str | None = None
+    oauth_client_id: str | None = None
+    oauth_client_secret: str | None = None
 
     request_timeout: int = 8
     session: ClientSession | None = None
+    token_storage: TokenStorage | None = None
 
+    _TOKEN_EXPIRY_MARGIN: int = 60
+
+    _get_oauth_token_task: asyncio.Task[None] | None = None
+    _expire_oauth_token_task: asyncio.Task[None] | None = None
     _close_session: bool = False
+
+    async def _check_api_key(self) -> None:
+        """Ensure valid authentication is available.
+
+        Raises
+        ------
+            TailscaleAuthenticationError: When neither api_key nor
+                oauth_client_id and oauth_client_secret are provided.
+
+        """
+        if not (
+            (self.api_key and not self.oauth_client_id and not self.oauth_client_secret)
+            or (not self.api_key and self.oauth_client_id and self.oauth_client_secret)
+            or (
+                self.api_key
+                and self.oauth_client_id
+                and self.oauth_client_secret
+                and self._get_oauth_token_task
+            )
+        ):
+            msg = (
+                "Either api_key or oauth_client_id and oauth_client_secret "
+                "are required when Tailscale client is initialized"
+            )
+            raise TailscaleAuthenticationError(msg)
+        if not self.api_key:
+            # Handle inconsistent state, e.g. manual token invalidation
+            if self._expire_oauth_token_task:
+                self._expire_oauth_token_task.cancel()
+                self._expire_oauth_token_task = None
+                if self._get_oauth_token_task:
+                    self._get_oauth_token_task.cancel()
+                    self._get_oauth_token_task = None
+            # Get a new OAuth token if not already in progress
+            if not self._get_oauth_token_task:
+                self._get_oauth_token_task = asyncio.create_task(
+                    self._get_oauth_token()
+                )
+            await self._get_oauth_token_task
+
+    async def _get_oauth_token(self) -> None:
+        """Get an OAuth token from the Tailscale API or token storage.
+
+        Raises
+        ------
+            TailscaleAuthenticationError: When access token is not found
+                in response or expires in less than 1 minute.
+
+        """
+        if self.token_storage:
+            token_data = await self.token_storage.get_token()
+            if token_data:
+                access_token, expires_at = token_data
+                expires_in = (expires_at - datetime.now(UTC)).total_seconds()
+                if expires_in > self._TOKEN_EXPIRY_MARGIN:
+                    self._expire_oauth_token_task = asyncio.create_task(
+                        self._expire_oauth_token(expires_in)
+                    )
+                    self.api_key = access_token
+                    return
+
+        data = {
+            "client_id": self.oauth_client_id,
+            "client_secret": self.oauth_client_secret,
+        }
+        response = await self._request(
+            "oauth/token",
+            data=data,
+            method=METH_POST,
+            _use_authentication=False,
+            _use_form_encoding=True,
+        )
+
+        json_response = orjson.loads(response)
+        access_token = str(json_response.get("access_token", ""))
+        expires_in = float(json_response.get("expires_in", 0))
+        if not access_token or not expires_in:
+            msg = "Failed to get OAuth token"
+            raise TailscaleAuthenticationError(msg)
+        if expires_in <= self._TOKEN_EXPIRY_MARGIN:
+            msg = "OAuth token expires in less than 1 minute"
+            raise TailscaleAuthenticationError(msg)
+
+        self._expire_oauth_token_task = asyncio.create_task(
+            self._expire_oauth_token(expires_in)
+        )
+        if self.token_storage:
+            expires_at = datetime.now(UTC) + timedelta(seconds=expires_in)
+            await self.token_storage.set_token(access_token, expires_at)
+        self.api_key = access_token
+
+    async def _expire_oauth_token(self, expires_in: float) -> None:
+        """Expire the OAuth token 1 minute before its expiration time."""
+        await asyncio.sleep(expires_in - self._TOKEN_EXPIRY_MARGIN)
+        self.api_key = None
+        self._get_oauth_token_task = None
+        self._expire_oauth_token_task = None
 
     async def _request(
         self,
@@ -38,6 +147,8 @@ class Tailscale:
         *,
         method: str = METH_GET,
         data: dict[str, Any] | None = None,
+        _use_authentication: bool = True,
+        _use_form_encoding: bool = False,
     ) -> str:
         """Handle a request to the Tailscale API.
 
@@ -49,6 +160,8 @@ class Tailscale:
             uri: Request URI, without '/api/v2/'.
             method: HTTP method to use.
             data: Dictionary of data to send to the Tailscale API.
+            _use_authentication: Whether to include authentication headers.
+            _use_form_encoding: Whether to use form encoding instead of JSON.
 
         Returns:
         -------
@@ -65,9 +178,13 @@ class Tailscale:
         """
         url = URL("https://api.tailscale.com/api/v2/").join(URL(uri))
 
-        headers = {
+        headers: dict[str, str] = {
             "Accept": "application/json",
         }
+
+        if _use_authentication:
+            await self._check_api_key()
+            headers["Authorization"] = f"Bearer {self.api_key}"
 
         if self.session is None:
             self.session = ClientSession()
@@ -78,9 +195,9 @@ class Tailscale:
                 response = await self.session.request(
                     method,
                     url,
-                    json=data,
-                    auth=BasicAuth(self.api_key),
                     headers=headers,
+                    data=data if _use_form_encoding else None,
+                    json=data if not _use_form_encoding else None,
                 )
                 response.raise_for_status()
         except TimeoutError as exception:
@@ -88,6 +205,12 @@ class Tailscale:
             raise TailscaleConnectionError(msg) from exception
         except ClientResponseError as exception:
             if exception.status in [401, 403]:
+                if _use_authentication and self.api_key and self.oauth_client_id:
+                    self.api_key = None
+                    self._get_oauth_token_task = None
+                    if self._expire_oauth_token_task:
+                        self._expire_oauth_token_task.cancel()
+                    self._expire_oauth_token_task = None
                 msg = "Authentication to the Tailscale API failed"
                 raise TailscaleAuthenticationError(msg) from exception
             msg = "Error occurred while connecting to the Tailscale API"
@@ -113,9 +236,13 @@ class Tailscale:
         return Devices.from_json(data).devices
 
     async def close(self) -> None:
-        """Close open client session."""
+        """Close open client session and cancel background tasks."""
         if self.session and self._close_session:
             await self.session.close()
+        if self._get_oauth_token_task:
+            self._get_oauth_token_task.cancel()
+        if self._expire_oauth_token_task:
+            self._expire_oauth_token_task.cancel()
 
     async def __aenter__(self) -> Self:
         """Async enter.

--- a/src/tailscale/tailscale.py
+++ b/src/tailscale/tailscale.py
@@ -3,12 +3,12 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import socket
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING, Any, Self
 
-import orjson
 from aiohttp.client import ClientError, ClientResponseError, ClientSession
 from aiohttp.hdrs import METH_GET, METH_POST
 from yarl import URL
@@ -38,7 +38,7 @@ class Tailscale:
     session: ClientSession | None = None
     token_storage: TokenStorage | None = None
 
-    _TOKEN_EXPIRY_MARGIN: int = 60
+    _token_expiry_margin: int = 60
 
     _get_oauth_token_task: asyncio.Task[None] | None = None
     _expire_oauth_token_task: asyncio.Task[None] | None = None
@@ -97,7 +97,7 @@ class Tailscale:
             if token_data:
                 access_token, expires_at = token_data
                 expires_in = (expires_at - datetime.now(UTC)).total_seconds()
-                if expires_in > self._TOKEN_EXPIRY_MARGIN:
+                if expires_in > self._token_expiry_margin:
                     self._expire_oauth_token_task = asyncio.create_task(
                         self._expire_oauth_token(expires_in)
                     )
@@ -116,13 +116,13 @@ class Tailscale:
             _use_form_encoding=True,
         )
 
-        json_response = orjson.loads(response)
+        json_response: dict[str, Any] = json.loads(response)
         access_token = str(json_response.get("access_token", ""))
         expires_in = float(json_response.get("expires_in", 0))
         if not access_token or not expires_in:
             msg = "Failed to get OAuth token"
             raise TailscaleAuthenticationError(msg)
-        if expires_in <= self._TOKEN_EXPIRY_MARGIN:
+        if expires_in <= self._token_expiry_margin:
             msg = "OAuth token expires in less than 1 minute"
             raise TailscaleAuthenticationError(msg)
 
@@ -136,7 +136,7 @@ class Tailscale:
 
     async def _expire_oauth_token(self, expires_in: float) -> None:
         """Expire the OAuth token 1 minute before its expiration time."""
-        await asyncio.sleep(expires_in - self._TOKEN_EXPIRY_MARGIN)
+        await asyncio.sleep(expires_in - self._token_expiry_margin)
         self.api_key = None
         self._get_oauth_token_task = None
         self._expire_oauth_token_task = None

--- a/tests/storage.py
+++ b/tests/storage.py
@@ -1,0 +1,27 @@
+"""In-memory token storage for testing."""
+
+from datetime import datetime
+
+from tailscale.storage import TokenStorage
+
+
+class InMemoryTokenStorage(TokenStorage):
+    """In-memory token storage for testing purposes."""
+
+    def __init__(
+        self, access_token: str | None = None, expires_at: datetime | None = None
+    ) -> None:
+        """Initialize the in-memory token storage."""
+        self._access_token = access_token
+        self._expires_at = expires_at
+
+    async def get_token(self) -> tuple[str, datetime] | None:
+        """Get the stored token."""
+        if self._access_token and self._expires_at:
+            return self._access_token, self._expires_at
+        return None
+
+    async def set_token(self, access_token: str, expires_at: datetime) -> None:
+        """Store the token."""
+        self._access_token = access_token
+        self._expires_at = expires_at

--- a/tests/test_tailscale.py
+++ b/tests/test_tailscale.py
@@ -468,8 +468,9 @@ async def test_too_short_oauth_expiration() -> None:
             await tailscale.close()
 
 
-async def test_http_error401_and_oauth_token_invalidation() -> None:
-    """Test HTTP 401 invalidates the OAuth token."""
+@pytest.mark.parametrize("status_code", [401, 403])
+async def test_http_auth_error_invalidates_oauth_token(status_code: int) -> None:
+    """Test HTTP 401/403 invalidates the OAuth token."""
     with aioresponses() as mocked:
         mocked.post(
             OAUTH_URL,
@@ -479,7 +480,7 @@ async def test_http_error401_and_oauth_token_invalidation() -> None:
         )
         mocked.get(
             f"{URL}/test",
-            status=401,
+            status=status_code,
             body="Access denied!",
             content_type="text/plain",
         )

--- a/tests/test_tailscale.py
+++ b/tests/test_tailscale.py
@@ -2,6 +2,9 @@
 
 # pylint: disable=protected-access
 
+import asyncio
+from datetime import UTC, datetime, timedelta
+
 import aiohttp
 import pytest
 from aioresponses import aioresponses
@@ -15,6 +18,9 @@ from tailscale.exceptions import (
 )
 
 from .conftest import URL, load_fixture
+from .storage import InMemoryTokenStorage
+
+OAUTH_URL = f"{URL}/oauth/token"
 
 
 async def test_json_request(
@@ -195,3 +201,298 @@ async def test_devices_empty_created(
     )
     devices = await tailscale_client.devices()
     assert devices["12345"].created is None
+
+
+# --- OAuth tests ---
+
+
+async def test_wrong_arguments_no_auth() -> None:
+    """Test that missing authentication raises an error."""
+    async with Tailscale() as tailscale:
+        with pytest.raises(TailscaleAuthenticationError):
+            await tailscale._request("test")
+
+
+async def test_wrong_arguments_both_auth() -> None:
+    """Test that providing both api_key and OAuth credentials raises an error."""
+    async with Tailscale(
+        api_key="abc",
+        oauth_client_id="client",
+        oauth_client_secret="notsosecret",  # noqa: S106
+    ) as tailscale:
+        with pytest.raises(TailscaleAuthenticationError):
+            await tailscale._request("test")
+
+
+async def test_wrong_arguments_partial_oauth() -> None:
+    """Test that providing only oauth_client_id raises an error."""
+    async with Tailscale(
+        oauth_client_id="client",
+    ) as tailscale:
+        with pytest.raises(TailscaleAuthenticationError):
+            await tailscale._request("test")
+
+
+async def test_key_from_oauth() -> None:
+    """Test OAuth token is retrieved and used for authentication."""
+    with aioresponses() as mocked:
+        mocked.post(
+            OAUTH_URL,
+            status=200,
+            body='{"access_token": "short-lived-token", "expires_in": 3600}',
+            content_type="application/json",
+        )
+        mocked.get(
+            f"{URL}/test",
+            status=200,
+            body='{"status": "ok"}',
+            content_type="application/json",
+        )
+        async with aiohttp.ClientSession() as session:
+            tailscale = Tailscale(
+                tailnet="frenck",
+                oauth_client_id="client",
+                oauth_client_secret="notsosecret",  # noqa: S106
+                session=session,
+            )
+            await tailscale._request("test")
+            assert tailscale.api_key == "short-lived-token"
+            await tailscale.close()
+
+
+async def test_key_from_oauth_with_race_condition() -> None:
+    """Test OAuth token request is sent only once under concurrent access."""
+    with aioresponses() as mocked:
+        mocked.post(
+            OAUTH_URL,
+            status=200,
+            body='{"access_token": "short-lived-token", "expires_in": 3600}',
+            content_type="application/json",
+        )
+        mocked.get(
+            f"{URL}/test",
+            status=200,
+            body='{"status": "ok"}',
+            content_type="application/json",
+        )
+        mocked.get(
+            f"{URL}/test",
+            status=200,
+            body='{"status": "ok"}',
+            content_type="application/json",
+        )
+        async with aiohttp.ClientSession() as session:
+            tailscale = Tailscale(
+                tailnet="frenck",
+                oauth_client_id="client",
+                oauth_client_secret="notsosecret",  # noqa: S106
+                session=session,
+            )
+            first_task = asyncio.create_task(tailscale._request("test"))
+            second_task = asyncio.create_task(tailscale._request("test"))
+            await asyncio.gather(first_task, second_task)
+            await tailscale.close()
+
+
+async def test_new_key_from_oauth_on_manual_invalidation() -> None:
+    """Test OAuth token is refreshed after manual invalidation."""
+    with aioresponses() as mocked:
+        mocked.post(
+            OAUTH_URL,
+            status=200,
+            body='{"access_token": "token-1", "expires_in": 3600}',
+            content_type="application/json",
+        )
+        mocked.get(
+            f"{URL}/test",
+            status=200,
+            body='{"status": "ok"}',
+            content_type="application/json",
+        )
+        mocked.post(
+            OAUTH_URL,
+            status=200,
+            body='{"access_token": "token-2", "expires_in": 3600}',
+            content_type="application/json",
+        )
+        mocked.get(
+            f"{URL}/test",
+            status=200,
+            body='{"status": "ok"}',
+            content_type="application/json",
+        )
+        async with aiohttp.ClientSession() as session:
+            tailscale = Tailscale(
+                tailnet="frenck",
+                oauth_client_id="client",
+                oauth_client_secret="notsosecret",  # noqa: S106
+                session=session,
+            )
+            await tailscale._request("test")
+            assert tailscale.api_key == "token-1"
+            tailscale.api_key = None
+            await tailscale._request("test")
+            assert tailscale.api_key == "token-2"
+            await tailscale.close()
+
+
+async def test_oauth_key_expiration() -> None:
+    """Test OAuth token is expired before its TTL."""
+    with aioresponses() as mocked:
+        mocked.post(
+            OAUTH_URL,
+            status=200,
+            body='{"access_token": "short-lived-token", "expires_in": 61}',
+            content_type="application/json",
+        )
+        mocked.get(
+            f"{URL}/test",
+            status=200,
+            body='{"status": "ok"}',
+            content_type="application/json",
+        )
+        async with aiohttp.ClientSession() as session:
+            tailscale = Tailscale(
+                tailnet="frenck",
+                oauth_client_id="client",
+                oauth_client_secret="notsosecret",  # noqa: S106
+                session=session,
+            )
+            await tailscale._request("test")
+            assert tailscale.api_key == "short-lived-token"
+            assert tailscale._expire_oauth_token_task is not None
+            await asyncio.sleep(2)
+            assert tailscale.api_key is None
+            assert tailscale._get_oauth_token_task is None
+            assert tailscale._expire_oauth_token_task is None
+            await tailscale.close()
+
+
+async def test_key_from_storage() -> None:
+    """Test OAuth token is loaded from token storage."""
+    with aioresponses() as mocked:
+        mocked.get(
+            f"{URL}/test",
+            status=200,
+            body='{"status": "ok"}',
+            content_type="application/json",
+        )
+        async with aiohttp.ClientSession() as session:
+            tailscale = Tailscale(
+                tailnet="frenck",
+                oauth_client_id="client",
+                oauth_client_secret="notsosecret",  # noqa: S106
+                session=session,
+                token_storage=InMemoryTokenStorage(
+                    "stored-token",
+                    datetime.now(UTC) + timedelta(hours=1),
+                ),
+            )
+            await tailscale._request("test")
+            assert tailscale.api_key == "stored-token"
+            await tailscale.close()
+
+
+async def test_expired_key_from_storage() -> None:
+    """Test expired token in storage triggers a fresh OAuth request."""
+    with aioresponses() as mocked:
+        mocked.post(
+            OAUTH_URL,
+            status=200,
+            body='{"access_token": "fresh-token", "expires_in": 3600}',
+            content_type="application/json",
+        )
+        mocked.get(
+            f"{URL}/test",
+            status=200,
+            body='{"status": "ok"}',
+            content_type="application/json",
+        )
+        async with aiohttp.ClientSession() as session:
+            token_storage = InMemoryTokenStorage(
+                "stored-token",
+                datetime.now(UTC) + timedelta(seconds=30),
+            )
+            tailscale = Tailscale(
+                tailnet="frenck",
+                oauth_client_id="client",
+                oauth_client_secret="notsosecret",  # noqa: S106
+                session=session,
+                token_storage=token_storage,
+            )
+            await tailscale._request("test")
+            assert tailscale.api_key == "fresh-token"
+            assert token_storage._access_token == "fresh-token"  # noqa: S105
+            await tailscale.close()
+
+
+async def test_bad_oauth() -> None:
+    """Test bad OAuth response raises an error."""
+    with aioresponses() as mocked:
+        mocked.post(
+            OAUTH_URL,
+            status=200,
+            body='{"error": "unauthorized"}',
+            content_type="application/json",
+        )
+        async with aiohttp.ClientSession() as session:
+            tailscale = Tailscale(
+                tailnet="frenck",
+                oauth_client_id="client",
+                oauth_client_secret="notsosecret",  # noqa: S106
+                session=session,
+            )
+            with pytest.raises(TailscaleAuthenticationError):
+                await tailscale._request("test")
+            await tailscale.close()
+
+
+async def test_too_short_oauth_expiration() -> None:
+    """Test OAuth token with too short expiration raises an error."""
+    with aioresponses() as mocked:
+        mocked.post(
+            OAUTH_URL,
+            status=200,
+            body='{"access_token": "short-lived-token", "expires_in": 60}',
+            content_type="application/json",
+        )
+        async with aiohttp.ClientSession() as session:
+            tailscale = Tailscale(
+                tailnet="frenck",
+                oauth_client_id="client",
+                oauth_client_secret="notsosecret",  # noqa: S106
+                session=session,
+            )
+            with pytest.raises(TailscaleAuthenticationError):
+                await tailscale._request("test")
+            await tailscale.close()
+
+
+async def test_http_error401_and_oauth_token_invalidation() -> None:
+    """Test HTTP 401 invalidates the OAuth token."""
+    with aioresponses() as mocked:
+        mocked.post(
+            OAUTH_URL,
+            status=200,
+            body='{"access_token": "short-lived-token", "expires_in": 3600}',
+            content_type="application/json",
+        )
+        mocked.get(
+            f"{URL}/test",
+            status=401,
+            body="Access denied!",
+            content_type="text/plain",
+        )
+        async with aiohttp.ClientSession() as session:
+            tailscale = Tailscale(
+                tailnet="frenck",
+                oauth_client_id="client",
+                oauth_client_secret="notsosecret",  # noqa: S106
+                session=session,
+            )
+            with pytest.raises(TailscaleAuthenticationError):
+                await tailscale._request("test")
+            assert tailscale.api_key is None
+            assert tailscale._get_oauth_token_task is None
+            assert tailscale._expire_oauth_token_task is None
+            await tailscale.close()


### PR DESCRIPTION
# Proposed Changes

Continuation of / supersedes #1260.

Plus fixed some things:
- handle race condition in _check_api_key()
- handle token expiration
- handle token invalidation
- fix argument validation condition
- fix attribute initialization
- remove magic constant
- add tests

Plus added possibility to automatically store and retrieve the received OAuth token.

## Related Issues

closes #1260 #1140
