### PR TITLE
Add user management endpoints and CLI commands

### DIFF
--- a/src/tailscale/__init__.py
+++ b/src/tailscale/__init__.py
@@ -15,6 +15,7 @@ from .models import (
     DNSPreferences,
     DNSSearchPaths,
     Latency,
+    TailscaleUser,
 )
 from .storage import TokenStorage
 from .tailscale import Tailscale
@@ -33,5 +34,6 @@ __all__ = [
     "TailscaleAuthenticationError",
     "TailscaleConnectionError",
     "TailscaleError",
+    "TailscaleUser",
     "TokenStorage",
 ]

--- a/src/tailscale/cli/__init__.py
+++ b/src/tailscale/cli/__init__.py
@@ -643,6 +643,89 @@ async def dns_split_command(
     console.print(table)
 
 
+@cli.command("users")
+async def users_command(
+    tailnet: Tailnet = "-",
+    api_key: ApiKey = None,
+    oauth_client_id: OAuthClientId = None,
+    oauth_client_secret: OAuthClientSecret = None,
+) -> None:
+    """List all users in the tailnet."""
+    client = _build_client(tailnet, api_key, oauth_client_id, oauth_client_secret)
+    async with client:
+        users = await client.users()
+
+    table = Table(title="Users", show_header=True, border_style="dim")
+    table.add_column("User ID", style="cyan")
+    table.add_column("Name", style="bold")
+    table.add_column("Login")
+    table.add_column("Role")
+    table.add_column("Status")
+    table.add_column("Devices", justify="right")
+    table.add_column("Connected")
+
+    for user in users:
+        connected = (
+            "[green]Yes[/green]" if user.currently_connected else "[dim]No[/dim]"
+        )
+        table.add_row(
+            user.user_id,
+            user.display_name,
+            user.login_name,
+            user.role,
+            user.status,
+            str(user.device_count or 0),
+            connected,
+        )
+
+    console.print(table)
+
+
+@cli.command("user")
+async def user_command(
+    user_id: Annotated[
+        str,
+        typer.Argument(help="User ID"),
+    ],
+    tailnet: Tailnet = "-",
+    api_key: ApiKey = None,
+    oauth_client_id: OAuthClientId = None,
+    oauth_client_secret: OAuthClientSecret = None,
+) -> None:
+    """Show detailed information for a single user."""
+    client = _build_client(tailnet, api_key, oauth_client_id, oauth_client_secret)
+    async with client:
+        user = await client.user(user_id)
+
+    info = Table(show_header=False, box=None, padding=(0, 2))
+    info.add_column("Field", style="bold")
+    info.add_column("Value")
+
+    info.add_row("User ID", user.user_id)
+    info.add_row("Name", user.display_name)
+    info.add_row("Login", user.login_name)
+    info.add_row("Role", user.role)
+    info.add_row("Status", user.status)
+    info.add_row("Type", user.user_type)
+
+    if user.device_count is not None:
+        info.add_row("Devices", str(user.device_count))
+
+    if user.currently_connected is not None:
+        connected = (
+            "[green]Yes[/green]" if user.currently_connected else "[dim]No[/dim]"
+        )
+        info.add_row("Connected", connected)
+
+    if user.last_seen:
+        info.add_row("Last Seen", str(user.last_seen))
+
+    if user.created:
+        info.add_row("Created", str(user.created))
+
+    console.print(Panel(info, title=user.display_name, border_style="green"))
+
+
 dump = AsyncTyper(
     help="Dump raw API responses as JSON (useful for debugging/fixtures).",
     no_args_is_help=True,
@@ -746,6 +829,42 @@ async def dump_dns_split_command(
     async with client:
         data = await client._request(  # noqa: SLF001
             f"tailnet/{client.tailnet}/dns/split-dns"
+        )
+    typer.echo(json.dumps(json.loads(data), indent=2, default=str))
+
+
+@dump.command("users")
+async def dump_users_command(
+    tailnet: Tailnet = "-",
+    api_key: ApiKey = None,
+    oauth_client_id: OAuthClientId = None,
+    oauth_client_secret: OAuthClientSecret = None,
+) -> None:
+    """Dump all users as raw JSON."""
+    client = _build_client(tailnet, api_key, oauth_client_id, oauth_client_secret)
+    async with client:
+        data = await client._request(  # noqa: SLF001
+            f"tailnet/{client.tailnet}/users"
+        )
+    typer.echo(json.dumps(json.loads(data), indent=2, default=str))
+
+
+@dump.command("user")
+async def dump_user_command(
+    user_id: Annotated[
+        str,
+        typer.Argument(help="User ID"),
+    ],
+    tailnet: Tailnet = "-",
+    api_key: ApiKey = None,
+    oauth_client_id: OAuthClientId = None,
+    oauth_client_secret: OAuthClientSecret = None,
+) -> None:
+    """Dump a single user as raw JSON."""
+    client = _build_client(tailnet, api_key, oauth_client_id, oauth_client_secret)
+    async with client:
+        data = await client._request(  # noqa: SLF001
+            f"users/{user_id}"
         )
     typer.echo(json.dumps(json.loads(data), indent=2, default=str))
 

--- a/src/tailscale/models.py
+++ b/src/tailscale/models.py
@@ -153,6 +153,36 @@ class DNSSearchPaths(DataClassORJSONMixin):
 
 
 @dataclass
+# pylint: disable-next=too-many-instance-attributes
+class TailscaleUser(DataClassORJSONMixin):
+    """Object holding Tailscale user information."""
+
+    user_id: str = field(metadata=field_options(alias="id"))
+    display_name: str = field(metadata=field_options(alias="displayName"))
+    login_name: str = field(metadata=field_options(alias="loginName"))
+    profile_pic_url: str = field(
+        default="", metadata=field_options(alias="profilePicURL")
+    )
+    role: str = ""
+    status: str = ""
+    user_type: str = field(default="", metadata=field_options(alias="type"))
+    created: datetime | None = None
+    currently_connected: bool | None = field(
+        default=None, metadata=field_options(alias="currentlyConnected")
+    )
+    device_count: int | None = field(
+        default=None, metadata=field_options(alias="deviceCount")
+    )
+    last_seen: datetime | None = field(
+        default=None,
+        metadata=field_options(alias="lastSeen"),
+    )
+    tailnet_lock_key: str | None = field(
+        default=None, metadata=field_options(alias="tailnetLockKey")
+    )
+
+
+@dataclass
 class DeviceRoutes(DataClassORJSONMixin):
     """Object holding Tailscale device route information."""
 

--- a/src/tailscale/tailscale.py
+++ b/src/tailscale/tailscale.py
@@ -25,6 +25,7 @@ from .models import (
     DNSNameservers,
     DNSPreferences,
     DNSSearchPaths,
+    TailscaleUser,
 )
 
 if TYPE_CHECKING:
@@ -538,6 +539,33 @@ class Tailscale:
             data=split_dns,
         )
         return json.loads(data)
+
+    async def users(self) -> list[TailscaleUser]:
+        """Get all users in the tailnet.
+
+        Returns
+        -------
+            A list of Tailscale users.
+
+        """
+        data = await self._request(f"tailnet/{self.tailnet}/users")
+        raw: list[dict[str, Any]] = json.loads(data).get("users", [])
+        return [TailscaleUser.from_dict(user) for user in raw]
+
+    async def user(self, user_id: str) -> TailscaleUser:
+        """Get a single user by ID.
+
+        Args:
+        ----
+            user_id: The ID of the user to retrieve.
+
+        Returns:
+        -------
+            The user information.
+
+        """
+        data = await self._request(f"users/{user_id}")
+        return TailscaleUser.from_json(data)
 
     async def close(self) -> None:
         """Close open client session and cancel background tasks."""

--- a/tests/__snapshots__/test_tailscale.ambr
+++ b/tests/__snapshots__/test_tailscale.ambr
@@ -20,3 +20,12 @@
 # name: test_dns_search_paths_snapshot
   DNSSearchPaths(search_paths=['corp.example.com', 'internal.example.com'])
 # ---
+# name: test_user_snapshot
+  TailscaleUser(user_id='u12345', display_name='Alice Engineer', login_name='alice@example.com', profile_pic_url='https://profiles.example.com/alice.jpg', role='admin', status='active', user_type='member', created=datetime.datetime(2024, 3, 15, 10, 0, tzinfo=datetime.timezone.utc), currently_connected=True, device_count=3, last_seen=datetime.datetime(2026, 4, 19, 12, 30, tzinfo=datetime.timezone.utc), tailnet_lock_key='tlpub:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890')
+# ---
+# name: test_users_snapshot
+  list([
+    TailscaleUser(user_id='u12345', display_name='Alice Engineer', login_name='alice@example.com', profile_pic_url='https://profiles.example.com/alice.jpg', role='admin', status='active', user_type='member', created=datetime.datetime(2024, 3, 15, 10, 0, tzinfo=datetime.timezone.utc), currently_connected=True, device_count=3, last_seen=datetime.datetime(2026, 4, 19, 12, 30, tzinfo=datetime.timezone.utc), tailnet_lock_key='tlpub:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890'),
+    TailscaleUser(user_id='u67890', display_name='Bob Ops', login_name='bob@example.com', profile_pic_url='', role='member', status='active', user_type='member', created=datetime.datetime(2025, 1, 20, 14, 30, tzinfo=datetime.timezone.utc), currently_connected=False, device_count=1, last_seen=datetime.datetime(2026, 4, 18, 9, 15, tzinfo=datetime.timezone.utc), tailnet_lock_key=''),
+  ])
+# ---

--- a/tests/cli/__snapshots__/test_cli.ambr
+++ b/tests/cli/__snapshots__/test_cli.ambr
@@ -144,6 +144,19 @@
         'oauth_client_secret',
         'tailnet',
       ]),
+      'user': list([
+        'api_key',
+        'oauth_client_id',
+        'oauth_client_secret',
+        'tailnet',
+        'user_id',
+      ]),
+      'users': list([
+        'api_key',
+        'oauth_client_id',
+        'oauth_client_secret',
+        'tailnet',
+      ]),
     }),
     'expire-key': list([
       'api_key',
@@ -197,6 +210,19 @@
       'oauth_client_id',
       'oauth_client_secret',
       'tags',
+      'tailnet',
+    ]),
+    'user': list([
+      'api_key',
+      'oauth_client_id',
+      'oauth_client_secret',
+      'tailnet',
+      'user_id',
+    ]),
+    'users': list([
+      'api_key',
+      'oauth_client_id',
+      'oauth_client_secret',
       'tailnet',
     ]),
   })
@@ -424,6 +450,35 @@
 # name: test_set_tags_command
   '''
   Tags set for device 12345: tag:server, tag:prod
+  
+  '''
+# ---
+# name: test_user_command
+  '''
+  ╭───────────────────────────────────────── Alice Engineer ─────────────────────────────────────────╮
+  │   User ID      u12345                                                                            │
+  │   Name         Alice Engineer                                                                    │
+  │   Login        alice@example.com                                                                 │
+  │   Role         admin                                                                             │
+  │   Status       active                                                                            │
+  │   Type         member                                                                            │
+  │   Devices      3                                                                                 │
+  │   Connected    Yes                                                                               │
+  │   Last Seen    2026-04-19 12:30:00+00:00                                                         │
+  │   Created      2024-03-15 10:00:00+00:00                                                         │
+  ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
+  
+  '''
+# ---
+# name: test_users_command
+  '''
+                                           Users                                          
+  ┏━━━━━━━━━┳━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━━━┓
+  ┃ User ID ┃ Name           ┃ Login             ┃ Role   ┃ Status ┃ Devices ┃ Connected ┃
+  ┡━━━━━━━━━╇━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━━━┩
+  │ u12345  │ Alice Engineer │ alice@example.com │ admin  │ active │       3 │ Yes       │
+  │ u67890  │ Bob Ops        │ bob@example.com   │ member │ active │       1 │ No        │
+  └─────────┴────────────────┴───────────────────┴────────┴────────┴─────────┴───────────┘
   
   '''
 # ---

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -25,6 +25,7 @@ from tailscale.models import (
     DNSNameservers,
     DNSPreferences,
     DNSSearchPaths,
+    TailscaleUser,
 )
 from tests.conftest import FIXTURES_DIR
 
@@ -343,6 +344,44 @@ def test_dns_set_search_paths_command(
     mock_client.set_dns_search_paths.assert_called_once_with(
         search_paths=["corp.example.com", "internal.example.com"]
     )
+
+
+# --- user commands ---
+
+
+def test_users_command(
+    runner: CliRunner,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Users command renders a table of all users."""
+    raw = json.loads(_load_fixture("users.json"))
+    users = [TailscaleUser.from_dict(u) for u in raw["users"]]
+    mock_client = _mock_tailscale()
+    mock_client.users.return_value = users
+    exit_code, output = _invoke(
+        runner,
+        ["users", "--api-key", "tskey-api-test"],
+        mock_client,
+    )
+    assert exit_code == 0
+    assert output == snapshot
+
+
+def test_user_command(
+    runner: CliRunner,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """User command renders detailed user information."""
+    user = TailscaleUser.from_json(_load_fixture("user.json"))
+    mock_client = _mock_tailscale()
+    mock_client.user.return_value = user
+    exit_code, output = _invoke(
+        runner,
+        ["user", "u12345", "--api-key", "tskey-api-test"],
+        mock_client,
+    )
+    assert exit_code == 0
+    assert output == snapshot
 
 
 # --- action commands ---

--- a/tests/fixtures/user.json
+++ b/tests/fixtures/user.json
@@ -1,0 +1,14 @@
+{
+  "id": "u12345",
+  "displayName": "Alice Engineer",
+  "loginName": "alice@example.com",
+  "profilePicURL": "https://profiles.example.com/alice.jpg",
+  "role": "admin",
+  "status": "active",
+  "type": "member",
+  "created": "2024-03-15T10:00:00Z",
+  "currentlyConnected": true,
+  "deviceCount": 3,
+  "lastSeen": "2026-04-19T12:30:00Z",
+  "tailnetLockKey": "tlpub:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
+}

--- a/tests/fixtures/users.json
+++ b/tests/fixtures/users.json
@@ -1,0 +1,32 @@
+{
+  "users": [
+    {
+      "id": "u12345",
+      "displayName": "Alice Engineer",
+      "loginName": "alice@example.com",
+      "profilePicURL": "https://profiles.example.com/alice.jpg",
+      "role": "admin",
+      "status": "active",
+      "type": "member",
+      "created": "2024-03-15T10:00:00Z",
+      "currentlyConnected": true,
+      "deviceCount": 3,
+      "lastSeen": "2026-04-19T12:30:00Z",
+      "tailnetLockKey": "tlpub:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
+    },
+    {
+      "id": "u67890",
+      "displayName": "Bob Ops",
+      "loginName": "bob@example.com",
+      "profilePicURL": "",
+      "role": "member",
+      "status": "active",
+      "type": "member",
+      "created": "2025-01-20T14:30:00Z",
+      "currentlyConnected": false,
+      "deviceCount": 1,
+      "lastSeen": "2026-04-18T09:15:00Z",
+      "tailnetLockKey": ""
+    }
+  ]
+}

--- a/tests/test_tailscale.py
+++ b/tests/test_tailscale.py
@@ -642,6 +642,83 @@ async def test_update_split_dns(
     }
 
 
+# --- User tests ---
+
+
+async def test_users(
+    responses: aioresponses,
+    tailscale_client: Tailscale,
+) -> None:
+    """Test fetching users from the Tailscale API."""
+    responses.get(
+        f"{URL}/tailnet/frenck/users",
+        status=200,
+        body=load_fixture("users.json"),
+        content_type="application/json",
+    )
+    users = await tailscale_client.users()
+    assert len(users) == 2
+    assert users[0].user_id == "u12345"
+    assert users[0].display_name == "Alice Engineer"
+    assert users[0].login_name == "alice@example.com"
+    assert users[0].role == "admin"
+    assert users[0].status == "active"
+    assert users[0].device_count == 3
+    assert users[0].currently_connected is True
+    assert users[1].user_id == "u67890"
+    assert users[1].display_name == "Bob Ops"
+    assert users[1].currently_connected is False
+
+
+async def test_users_snapshot(
+    responses: aioresponses,
+    tailscale_client: Tailscale,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test users parsing matches snapshot."""
+    responses.get(
+        f"{URL}/tailnet/frenck/users",
+        status=200,
+        body=load_fixture("users.json"),
+        content_type="application/json",
+    )
+    assert await tailscale_client.users() == snapshot
+
+
+async def test_user(
+    responses: aioresponses,
+    tailscale_client: Tailscale,
+) -> None:
+    """Test fetching a single user from the Tailscale API."""
+    responses.get(
+        f"{URL}/users/u12345",
+        status=200,
+        body=load_fixture("user.json"),
+        content_type="application/json",
+    )
+    user = await tailscale_client.user("u12345")
+    assert user.user_id == "u12345"
+    assert user.display_name == "Alice Engineer"
+    assert user.login_name == "alice@example.com"
+    assert user.role == "admin"
+    assert user.device_count == 3
+
+
+async def test_user_snapshot(
+    responses: aioresponses,
+    tailscale_client: Tailscale,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test single user parsing matches snapshot."""
+    responses.get(
+        f"{URL}/users/u12345",
+        status=200,
+        body=load_fixture("user.json"),
+        content_type="application/json",
+    )
+    assert await tailscale_client.user("u12345") == snapshot
+
+
 # --- OAuth tests ---
 
 


### PR DESCRIPTION
# Proposed Changes

- Add `TailscaleUser` model with 12 fields (id, name, login, role, status, type, connected, devices, etc.)
- Add `users()` and `user()` client methods
- Add `users` and `user` CLI commands with Rich-formatted output
- Add `dump users` and `dump user` commands for fixture collection
- Fix `test_missing_auth` to clear env vars (was environment-dependent)
- Add pylint `too-many-instance-attributes` suppression for `TailscaleUser`