### PR TITLE
Add tailnet settings endpoints and CLI command

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,6 +128,7 @@ ignore = [
 
 [tool.ruff.lint.per-file-ignores]
 "src/tailscale/cli/**/*.py" = [
+  "FBT001",  # Boolean positional args needed for display helpers
   "FBT002",  # Boolean defaults needed for Typer flag options
   "PLR0913", # CLI commands need many params (device_id + auth options)
 ]

--- a/src/tailscale/__init__.py
+++ b/src/tailscale/__init__.py
@@ -15,6 +15,7 @@ from .models import (
     DNSPreferences,
     DNSSearchPaths,
     Latency,
+    TailnetSettings,
     TailscaleUser,
 )
 from .storage import TokenStorage
@@ -30,6 +31,7 @@ __all__ = [
     "DeviceRoutes",
     "Devices",
     "Latency",
+    "TailnetSettings",
     "Tailscale",
     "TailscaleAuthenticationError",
     "TailscaleConnectionError",

--- a/src/tailscale/cli/__init__.py
+++ b/src/tailscale/cli/__init__.py
@@ -726,6 +726,43 @@ async def user_command(
     console.print(Panel(info, title=user.display_name, border_style="green"))
 
 
+@cli.command("settings")
+async def settings_command(
+    tailnet: Tailnet = "-",
+    api_key: ApiKey = None,
+    oauth_client_id: OAuthClientId = None,
+    oauth_client_secret: OAuthClientSecret = None,
+) -> None:
+    """Show the tailnet settings."""
+    client = _build_client(tailnet, api_key, oauth_client_id, oauth_client_secret)
+    async with client:
+        settings = await client.tailnet_settings()
+
+    table = Table(title="Tailnet Settings", show_header=True, border_style="dim")
+    table.add_column("Setting", style="bold")
+    table.add_column("Value")
+
+    def _bool(val: bool) -> str:
+        return "[green]Yes[/green]" if val else "[dim]No[/dim]"
+
+    table.add_row("Device Approval", _bool(settings.devices_approval_on))
+    table.add_row("Auto Updates", _bool(settings.devices_auto_updates_on))
+    table.add_row("Key Duration", f"{settings.devices_key_duration_days} days")
+    table.add_row("User Approval", _bool(settings.users_approval_on))
+    table.add_row(
+        "External Tailnets",
+        settings.users_role_allowed_to_join_external_tailnets,
+    )
+    table.add_row("Network Flow Logging", _bool(settings.network_flow_logging_on))
+    table.add_row("Regional Routing", _bool(settings.regional_routing_on))
+    table.add_row(
+        "Posture Identity Collection",
+        _bool(settings.posture_identity_collection_on),
+    )
+
+    console.print(table)
+
+
 dump = AsyncTyper(
     help="Dump raw API responses as JSON (useful for debugging/fixtures).",
     no_args_is_help=True,
@@ -865,6 +902,22 @@ async def dump_user_command(
     async with client:
         data = await client._request(  # noqa: SLF001
             f"users/{user_id}"
+        )
+    typer.echo(json.dumps(json.loads(data), indent=2, default=str))
+
+
+@dump.command("settings")
+async def dump_settings_command(
+    tailnet: Tailnet = "-",
+    api_key: ApiKey = None,
+    oauth_client_id: OAuthClientId = None,
+    oauth_client_secret: OAuthClientSecret = None,
+) -> None:
+    """Dump tailnet settings as raw JSON."""
+    client = _build_client(tailnet, api_key, oauth_client_id, oauth_client_secret)
+    async with client:
+        data = await client._request(  # noqa: SLF001
+            f"tailnet/{client.tailnet}/settings"
         )
     typer.echo(json.dumps(json.loads(data), indent=2, default=str))
 

--- a/src/tailscale/models.py
+++ b/src/tailscale/models.py
@@ -154,6 +154,39 @@ class DNSSearchPaths(DataClassORJSONMixin):
 
 @dataclass
 # pylint: disable-next=too-many-instance-attributes
+class TailnetSettings(DataClassORJSONMixin):
+    """Object holding tailnet-wide settings."""
+
+    devices_approval_on: bool = field(
+        default=False, metadata=field_options(alias="devicesApprovalOn")
+    )
+    devices_auto_updates_on: bool = field(
+        default=False, metadata=field_options(alias="devicesAutoUpdatesOn")
+    )
+    devices_key_duration_days: int = field(
+        default=180, metadata=field_options(alias="devicesKeyDurationDays")
+    )
+    users_approval_on: bool = field(
+        default=False, metadata=field_options(alias="usersApprovalOn")
+    )
+    users_role_allowed_to_join_external_tailnets: str = field(
+        default="none",
+        metadata=field_options(alias="usersRoleAllowedToJoinExternalTailnets"),
+    )
+    network_flow_logging_on: bool = field(
+        default=False, metadata=field_options(alias="networkFlowLoggingOn")
+    )
+    regional_routing_on: bool = field(
+        default=False, metadata=field_options(alias="regionalRoutingOn")
+    )
+    posture_identity_collection_on: bool = field(
+        default=False,
+        metadata=field_options(alias="postureIdentityCollectionOn"),
+    )
+
+
+@dataclass
+# pylint: disable-next=too-many-instance-attributes
 class TailscaleUser(DataClassORJSONMixin):
     """Object holding Tailscale user information."""
 

--- a/src/tailscale/tailscale.py
+++ b/src/tailscale/tailscale.py
@@ -25,6 +25,7 @@ from .models import (
     DNSNameservers,
     DNSPreferences,
     DNSSearchPaths,
+    TailnetSettings,
     TailscaleUser,
 )
 
@@ -566,6 +567,73 @@ class Tailscale:
         """
         data = await self._request(f"users/{user_id}")
         return TailscaleUser.from_json(data)
+
+    async def tailnet_settings(self) -> TailnetSettings:
+        """Get the settings for the tailnet.
+
+        Returns
+        -------
+            The tailnet settings.
+
+        """
+        data = await self._request(f"tailnet/{self.tailnet}/settings")
+        return TailnetSettings.from_json(data)
+
+    async def update_tailnet_settings(  # noqa: PLR0913  # pylint: disable=too-many-arguments
+        self,
+        *,
+        devices_approval_on: bool | None = None,
+        devices_auto_updates_on: bool | None = None,
+        devices_key_duration_days: int | None = None,
+        users_approval_on: bool | None = None,
+        users_role_allowed_to_join_external_tailnets: str | None = None,
+        network_flow_logging_on: bool | None = None,
+        regional_routing_on: bool | None = None,
+        posture_identity_collection_on: bool | None = None,
+    ) -> None:
+        """Update the settings for the tailnet.
+
+        Only provided parameters are updated; omitted parameters
+        are left unchanged.
+
+        Args:
+        ----
+            devices_approval_on: Whether device approval is required.
+            devices_auto_updates_on: Whether auto-updates are enabled.
+            devices_key_duration_days: Key expiry duration in days.
+            users_approval_on: Whether user approval is required.
+            users_role_allowed_to_join_external_tailnets: Role allowed
+                to join external tailnets ("none", "admin", "member").
+            network_flow_logging_on: Whether network flow logging is on.
+            regional_routing_on: Whether regional routing is on.
+            posture_identity_collection_on: Whether posture identity
+                collection is on.
+
+        """
+        payload: dict[str, Any] = {}
+        if devices_approval_on is not None:
+            payload["devicesApprovalOn"] = devices_approval_on
+        if devices_auto_updates_on is not None:
+            payload["devicesAutoUpdatesOn"] = devices_auto_updates_on
+        if devices_key_duration_days is not None:
+            payload["devicesKeyDurationDays"] = devices_key_duration_days
+        if users_approval_on is not None:
+            payload["usersApprovalOn"] = users_approval_on
+        if users_role_allowed_to_join_external_tailnets is not None:
+            payload["usersRoleAllowedToJoinExternalTailnets"] = (
+                users_role_allowed_to_join_external_tailnets
+            )
+        if network_flow_logging_on is not None:
+            payload["networkFlowLoggingOn"] = network_flow_logging_on
+        if regional_routing_on is not None:
+            payload["regionalRoutingOn"] = regional_routing_on
+        if posture_identity_collection_on is not None:
+            payload["postureIdentityCollectionOn"] = posture_identity_collection_on
+        await self._request(
+            f"tailnet/{self.tailnet}/settings",
+            method=METH_PATCH,
+            data=payload,
+        )
 
     async def close(self) -> None:
         """Close open client session and cancel background tasks."""

--- a/tests/__snapshots__/test_tailscale.ambr
+++ b/tests/__snapshots__/test_tailscale.ambr
@@ -20,6 +20,9 @@
 # name: test_dns_search_paths_snapshot
   DNSSearchPaths(search_paths=['corp.example.com', 'internal.example.com'])
 # ---
+# name: test_tailnet_settings_snapshot
+  TailnetSettings(devices_approval_on=True, devices_auto_updates_on=True, devices_key_duration_days=90, users_approval_on=False, users_role_allowed_to_join_external_tailnets='admin', network_flow_logging_on=True, regional_routing_on=False, posture_identity_collection_on=True)
+# ---
 # name: test_user_snapshot
   TailscaleUser(user_id='u12345', display_name='Alice Engineer', login_name='alice@example.com', profile_pic_url='https://profiles.example.com/alice.jpg', role='admin', status='active', user_type='member', created=datetime.datetime(2024, 3, 15, 10, 0, tzinfo=datetime.timezone.utc), currently_connected=True, device_count=3, last_seen=datetime.datetime(2026, 4, 19, 12, 30, tzinfo=datetime.timezone.utc), tailnet_lock_key='tlpub:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890')
 # ---

--- a/tests/cli/__snapshots__/test_cli.ambr
+++ b/tests/cli/__snapshots__/test_cli.ambr
@@ -144,6 +144,12 @@
         'oauth_client_secret',
         'tailnet',
       ]),
+      'settings': list([
+        'api_key',
+        'oauth_client_id',
+        'oauth_client_secret',
+        'tailnet',
+      ]),
       'user': list([
         'api_key',
         'oauth_client_id',
@@ -210,6 +216,12 @@
       'oauth_client_id',
       'oauth_client_secret',
       'tags',
+      'tailnet',
+    ]),
+    'settings': list([
+      'api_key',
+      'oauth_client_id',
+      'oauth_client_secret',
       'tailnet',
     ]),
     'user': list([
@@ -450,6 +462,24 @@
 # name: test_set_tags_command
   '''
   Tags set for device 12345: tag:server, tag:prod
+  
+  '''
+# ---
+# name: test_settings_command
+  '''
+              Tailnet Settings             
+  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━┓
+  ┃ Setting                     ┃ Value   ┃
+  ┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━┩
+  │ Device Approval             │ Yes     │
+  │ Auto Updates                │ Yes     │
+  │ Key Duration                │ 90 days │
+  │ User Approval               │ No      │
+  │ External Tailnets           │ admin   │
+  │ Network Flow Logging        │ Yes     │
+  │ Regional Routing            │ No      │
+  │ Posture Identity Collection │ Yes     │
+  └─────────────────────────────┴─────────┘
   
   '''
 # ---

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -25,6 +25,7 @@ from tailscale.models import (
     DNSNameservers,
     DNSPreferences,
     DNSSearchPaths,
+    TailnetSettings,
     TailscaleUser,
 )
 from tests.conftest import FIXTURES_DIR
@@ -378,6 +379,26 @@ def test_user_command(
     exit_code, output = _invoke(
         runner,
         ["user", "u12345", "--api-key", "tskey-api-test"],
+        mock_client,
+    )
+    assert exit_code == 0
+    assert output == snapshot
+
+
+# --- settings command ---
+
+
+def test_settings_command(
+    runner: CliRunner,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Settings command renders a table of tailnet settings."""
+    settings = TailnetSettings.from_json(_load_fixture("tailnet_settings.json"))
+    mock_client = _mock_tailscale()
+    mock_client.tailnet_settings.return_value = settings
+    exit_code, output = _invoke(
+        runner,
+        ["settings", "--api-key", "tskey-api-test"],
         mock_client,
     )
     assert exit_code == 0

--- a/tests/fixtures/tailnet_settings.json
+++ b/tests/fixtures/tailnet_settings.json
@@ -1,0 +1,10 @@
+{
+  "devicesApprovalOn": true,
+  "devicesAutoUpdatesOn": true,
+  "devicesKeyDurationDays": 90,
+  "usersApprovalOn": false,
+  "usersRoleAllowedToJoinExternalTailnets": "admin",
+  "networkFlowLoggingOn": true,
+  "regionalRoutingOn": false,
+  "postureIdentityCollectionOn": true
+}

--- a/tests/test_tailscale.py
+++ b/tests/test_tailscale.py
@@ -719,6 +719,63 @@ async def test_user_snapshot(
     assert await tailscale_client.user("u12345") == snapshot
 
 
+# --- Tailnet settings tests ---
+
+
+async def test_tailnet_settings(
+    responses: aioresponses,
+    tailscale_client: Tailscale,
+) -> None:
+    """Test getting tailnet settings."""
+    responses.get(
+        f"{URL}/tailnet/frenck/settings",
+        status=200,
+        body=load_fixture("tailnet_settings.json"),
+        content_type="application/json",
+    )
+    result = await tailscale_client.tailnet_settings()
+    assert result.devices_approval_on is True
+    assert result.devices_auto_updates_on is True
+    assert result.devices_key_duration_days == 90
+    assert result.users_approval_on is False
+    assert result.users_role_allowed_to_join_external_tailnets == "admin"
+    assert result.network_flow_logging_on is True
+    assert result.regional_routing_on is False
+    assert result.posture_identity_collection_on is True
+
+
+async def test_tailnet_settings_snapshot(
+    responses: aioresponses,
+    tailscale_client: Tailscale,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test tailnet settings parsing matches snapshot."""
+    responses.get(
+        f"{URL}/tailnet/frenck/settings",
+        status=200,
+        body=load_fixture("tailnet_settings.json"),
+        content_type="application/json",
+    )
+    assert await tailscale_client.tailnet_settings() == snapshot
+
+
+async def test_update_tailnet_settings(
+    responses: aioresponses,
+    tailscale_client: Tailscale,
+) -> None:
+    """Test updating tailnet settings."""
+    responses.patch(
+        f"{URL}/tailnet/frenck/settings",
+        status=200,
+        body="",
+        content_type="application/json",
+    )
+    await tailscale_client.update_tailnet_settings(
+        devices_key_duration_days=30,
+        network_flow_logging_on=False,
+    )
+
+
 # --- OAuth tests ---
 
 


### PR DESCRIPTION
# Proposed Changes

- Add `TailnetSettings` model with 8 fields (device approval, auto-updates, key duration, user approval, external tailnets, network flow logging, regional routing, posture identity)
- Add `tailnet_settings()` and `update_tailnet_settings()` client methods (GET + PATCH)
- Add `settings` CLI command with Rich-formatted table
- Add `dump settings` command for fixture collection
