### PR TITLE
Add missing fixtures, dump tests, CLI settings management, and complete README docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,10 +83,44 @@ tailscale set-routes nSRVBN3CNTRL 10.0.0.0/24 192.168.1.0/24
 # Set Tailscale IPv4 address
 tailscale set-ip nSRVBN3CNTRL 100.64.0.1
 
+# DNS management
+tailscale dns nameservers
+tailscale dns set-nameservers 8.8.8.8 1.1.1.1
+tailscale dns preferences
+tailscale dns set-preferences --magic-dns
+tailscale dns search-paths
+tailscale dns set-search-paths corp.example.com
+tailscale dns split
+
+# List users and show user details
+tailscale users
+tailscale user u12345
+
+# Tailnet settings
+tailscale settings show
+tailscale settings device-approval --enable
+tailscale settings auto-updates --disable
+tailscale settings key-duration 90
+tailscale settings network-flow-logging --enable
+tailscale settings external-tailnets admin
+
+# List and manage auth keys
+tailscale keys
+tailscale delete-key k1234567890abcdef
+
 # Dump raw API responses as JSON (useful for debugging/fixtures)
 tailscale dump devices
 tailscale dump device nSRVBN3CNTRL
 tailscale dump routes nSRVBN3CNTRL
+tailscale dump dns-nameservers
+tailscale dump dns-preferences
+tailscale dump dns-search-paths
+tailscale dump dns-split
+tailscale dump users
+tailscale dump user u12345
+tailscale dump settings
+tailscale dump keys
+tailscale dump key k1234567890abcdef
 ```
 
 OAuth authentication is also supported via `--oauth-client-id` and

--- a/src/tailscale/cli/__init__.py
+++ b/src/tailscale/cli/__init__.py
@@ -726,8 +726,20 @@ async def user_command(
     console.print(Panel(info, title=user.display_name, border_style="green"))
 
 
-@cli.command("settings")
-async def settings_command(
+settings = AsyncTyper(
+    help="View and manage tailnet settings.",
+    no_args_is_help=True,
+)
+cli.add_typer(settings, name="settings")
+
+
+def _bool_display(val: bool) -> str:
+    """Format a boolean for Rich display."""
+    return "[green]Yes[/green]" if val else "[dim]No[/dim]"
+
+
+@settings.command("show")
+async def settings_show_command(
     tailnet: Tailnet = "-",
     api_key: ApiKey = None,
     oauth_client_id: OAuthClientId = None,
@@ -736,28 +748,25 @@ async def settings_command(
     """Show the tailnet settings."""
     client = _build_client(tailnet, api_key, oauth_client_id, oauth_client_secret)
     async with client:
-        settings = await client.tailnet_settings()
+        s = await client.tailnet_settings()
 
     table = Table(title="Tailnet Settings", show_header=True, border_style="dim")
     table.add_column("Setting", style="bold")
     table.add_column("Value")
 
-    def _bool(val: bool) -> str:
-        return "[green]Yes[/green]" if val else "[dim]No[/dim]"
-
-    table.add_row("Device Approval", _bool(settings.devices_approval_on))
-    table.add_row("Auto Updates", _bool(settings.devices_auto_updates_on))
-    table.add_row("Key Duration", f"{settings.devices_key_duration_days} days")
-    table.add_row("User Approval", _bool(settings.users_approval_on))
+    table.add_row("Device Approval", _bool_display(s.devices_approval_on))
+    table.add_row("Auto Updates", _bool_display(s.devices_auto_updates_on))
+    table.add_row("Key Duration", f"{s.devices_key_duration_days} days")
+    table.add_row("User Approval", _bool_display(s.users_approval_on))
     table.add_row(
         "External Tailnets",
-        settings.users_role_allowed_to_join_external_tailnets,
+        s.users_role_allowed_to_join_external_tailnets,
     )
-    table.add_row("Network Flow Logging", _bool(settings.network_flow_logging_on))
-    table.add_row("Regional Routing", _bool(settings.regional_routing_on))
+    table.add_row("Network Flow Logging", _bool_display(s.network_flow_logging_on))
+    table.add_row("Regional Routing", _bool_display(s.regional_routing_on))
     table.add_row(
         "Posture Identity Collection",
-        _bool(settings.posture_identity_collection_on),
+        _bool_display(s.posture_identity_collection_on),
     )
 
     console.print(table)
@@ -823,6 +832,165 @@ async def delete_key_command(
     async with client:
         await client.delete_key(key_id)
     console.print(f"[red]Key {key_id} deleted.[/red]")
+
+
+@settings.command("device-approval")
+async def settings_device_approval_command(
+    enable: Annotated[
+        bool,
+        typer.Option("--enable/--disable", help="Enable or disable device approval"),
+    ],
+    tailnet: Tailnet = "-",
+    api_key: ApiKey = None,
+    oauth_client_id: OAuthClientId = None,
+    oauth_client_secret: OAuthClientSecret = None,
+) -> None:
+    """Enable or disable device approval."""
+    client = _build_client(tailnet, api_key, oauth_client_id, oauth_client_secret)
+    async with client:
+        await client.update_tailnet_settings(devices_approval_on=enable)
+    state = "enabled" if enable else "disabled"
+    console.print(f"[green]Device approval {state}.[/green]")
+
+
+@settings.command("auto-updates")
+async def settings_auto_updates_command(
+    enable: Annotated[
+        bool,
+        typer.Option("--enable/--disable", help="Enable or disable auto-updates"),
+    ],
+    tailnet: Tailnet = "-",
+    api_key: ApiKey = None,
+    oauth_client_id: OAuthClientId = None,
+    oauth_client_secret: OAuthClientSecret = None,
+) -> None:
+    """Enable or disable device auto-updates."""
+    client = _build_client(tailnet, api_key, oauth_client_id, oauth_client_secret)
+    async with client:
+        await client.update_tailnet_settings(devices_auto_updates_on=enable)
+    state = "enabled" if enable else "disabled"
+    console.print(f"[green]Auto-updates {state}.[/green]")
+
+
+@settings.command("key-duration")
+async def settings_key_duration_command(
+    days: Annotated[
+        int,
+        typer.Argument(help="Key expiry duration in days"),
+    ],
+    tailnet: Tailnet = "-",
+    api_key: ApiKey = None,
+    oauth_client_id: OAuthClientId = None,
+    oauth_client_secret: OAuthClientSecret = None,
+) -> None:
+    """Set the device key expiry duration."""
+    client = _build_client(tailnet, api_key, oauth_client_id, oauth_client_secret)
+    async with client:
+        await client.update_tailnet_settings(devices_key_duration_days=days)
+    console.print(f"[green]Key duration set to {days} days.[/green]")
+
+
+@settings.command("user-approval")
+async def settings_user_approval_command(
+    enable: Annotated[
+        bool,
+        typer.Option("--enable/--disable", help="Enable or disable user approval"),
+    ],
+    tailnet: Tailnet = "-",
+    api_key: ApiKey = None,
+    oauth_client_id: OAuthClientId = None,
+    oauth_client_secret: OAuthClientSecret = None,
+) -> None:
+    """Enable or disable user approval."""
+    client = _build_client(tailnet, api_key, oauth_client_id, oauth_client_secret)
+    async with client:
+        await client.update_tailnet_settings(users_approval_on=enable)
+    state = "enabled" if enable else "disabled"
+    console.print(f"[green]User approval {state}.[/green]")
+
+
+@settings.command("external-tailnets")
+async def settings_external_tailnets_command(
+    role: Annotated[
+        str,
+        typer.Argument(help="Role for external tailnets (none/admin/member)"),
+    ],
+    tailnet: Tailnet = "-",
+    api_key: ApiKey = None,
+    oauth_client_id: OAuthClientId = None,
+    oauth_client_secret: OAuthClientSecret = None,
+) -> None:
+    """Set which role can join external tailnets."""
+    client = _build_client(tailnet, api_key, oauth_client_id, oauth_client_secret)
+    async with client:
+        await client.update_tailnet_settings(
+            users_role_allowed_to_join_external_tailnets=role,
+        )
+    console.print(f"[green]External tailnets role set to {role}.[/green]")
+
+
+@settings.command("network-flow-logging")
+async def settings_network_flow_logging_command(
+    enable: Annotated[
+        bool,
+        typer.Option(
+            "--enable/--disable", help="Enable or disable network flow logging"
+        ),
+    ],
+    tailnet: Tailnet = "-",
+    api_key: ApiKey = None,
+    oauth_client_id: OAuthClientId = None,
+    oauth_client_secret: OAuthClientSecret = None,
+) -> None:
+    """Enable or disable network flow logging."""
+    client = _build_client(tailnet, api_key, oauth_client_id, oauth_client_secret)
+    async with client:
+        await client.update_tailnet_settings(network_flow_logging_on=enable)
+    state = "enabled" if enable else "disabled"
+    console.print(f"[green]Network flow logging {state}.[/green]")
+
+
+@settings.command("regional-routing")
+async def settings_regional_routing_command(
+    enable: Annotated[
+        bool,
+        typer.Option("--enable/--disable", help="Enable or disable regional routing"),
+    ],
+    tailnet: Tailnet = "-",
+    api_key: ApiKey = None,
+    oauth_client_id: OAuthClientId = None,
+    oauth_client_secret: OAuthClientSecret = None,
+) -> None:
+    """Enable or disable regional routing."""
+    client = _build_client(tailnet, api_key, oauth_client_id, oauth_client_secret)
+    async with client:
+        await client.update_tailnet_settings(regional_routing_on=enable)
+    state = "enabled" if enable else "disabled"
+    console.print(f"[green]Regional routing {state}.[/green]")
+
+
+@settings.command("posture-identity")
+async def settings_posture_identity_command(
+    enable: Annotated[
+        bool,
+        typer.Option(
+            "--enable/--disable",
+            help="Enable or disable posture identity collection",
+        ),
+    ],
+    tailnet: Tailnet = "-",
+    api_key: ApiKey = None,
+    oauth_client_id: OAuthClientId = None,
+    oauth_client_secret: OAuthClientSecret = None,
+) -> None:
+    """Enable or disable posture identity collection."""
+    client = _build_client(tailnet, api_key, oauth_client_id, oauth_client_secret)
+    async with client:
+        await client.update_tailnet_settings(
+            posture_identity_collection_on=enable,
+        )
+    state = "enabled" if enable else "disabled"
+    console.print(f"[green]Posture identity collection {state}.[/green]")
 
 
 dump = AsyncTyper(

--- a/tests/cli/__snapshots__/test_cli.ambr
+++ b/tests/cli/__snapshots__/test_cli.ambr
@@ -244,12 +244,70 @@
       'tags',
       'tailnet',
     ]),
-    'settings': list([
-      'api_key',
-      'oauth_client_id',
-      'oauth_client_secret',
-      'tailnet',
-    ]),
+    'settings': dict({
+      'auto-updates': list([
+        'api_key',
+        'enable',
+        'oauth_client_id',
+        'oauth_client_secret',
+        'tailnet',
+      ]),
+      'device-approval': list([
+        'api_key',
+        'enable',
+        'oauth_client_id',
+        'oauth_client_secret',
+        'tailnet',
+      ]),
+      'external-tailnets': list([
+        'api_key',
+        'oauth_client_id',
+        'oauth_client_secret',
+        'role',
+        'tailnet',
+      ]),
+      'key-duration': list([
+        'api_key',
+        'days',
+        'oauth_client_id',
+        'oauth_client_secret',
+        'tailnet',
+      ]),
+      'network-flow-logging': list([
+        'api_key',
+        'enable',
+        'oauth_client_id',
+        'oauth_client_secret',
+        'tailnet',
+      ]),
+      'posture-identity': list([
+        'api_key',
+        'enable',
+        'oauth_client_id',
+        'oauth_client_secret',
+        'tailnet',
+      ]),
+      'regional-routing': list([
+        'api_key',
+        'enable',
+        'oauth_client_id',
+        'oauth_client_secret',
+        'tailnet',
+      ]),
+      'show': list([
+        'api_key',
+        'oauth_client_id',
+        'oauth_client_secret',
+        'tailnet',
+      ]),
+      'user-approval': list([
+        'api_key',
+        'enable',
+        'oauth_client_id',
+        'oauth_client_secret',
+        'tailnet',
+      ]),
+    }),
     'user': list([
       'api_key',
       'oauth_client_id',
@@ -511,7 +569,25 @@
   
   '''
 # ---
-# name: test_settings_command
+# name: test_settings_device_approval_command
+  '''
+  Device approval enabled.
+  
+  '''
+# ---
+# name: test_settings_external_tailnets_command
+  '''
+  External tailnets role set to admin.
+  
+  '''
+# ---
+# name: test_settings_key_duration_command
+  '''
+  Key duration set to 90 days.
+  
+  '''
+# ---
+# name: test_settings_show_command
   '''
               Tailnet Settings             
   ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━┓

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -423,24 +423,78 @@ def test_delete_key_command(
     mock_client.delete_key.assert_called_once_with("k1234567890abcdef")
 
 
-# --- settings command ---
+# --- settings commands ---
 
 
-def test_settings_command(
+def test_settings_show_command(
     runner: CliRunner,
     snapshot: SnapshotAssertion,
 ) -> None:
-    """Settings command renders a table of tailnet settings."""
-    settings = TailnetSettings.from_json(_load_fixture("tailnet_settings.json"))
+    """Settings show command renders a table of tailnet settings."""
+    ts = TailnetSettings.from_json(_load_fixture("tailnet_settings.json"))
     mock_client = _mock_tailscale()
-    mock_client.tailnet_settings.return_value = settings
+    mock_client.tailnet_settings.return_value = ts
     exit_code, output = _invoke(
         runner,
-        ["settings", "--api-key", "tskey-api-test"],
+        ["settings", "show", "--api-key", "tskey-api-test"],
         mock_client,
     )
     assert exit_code == 0
     assert output == snapshot
+
+
+def test_settings_device_approval_command(
+    runner: CliRunner,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Settings device-approval command prints confirmation."""
+    mock_client = _mock_tailscale()
+    exit_code, output = _invoke(
+        runner,
+        ["settings", "device-approval", "--enable", "--api-key", "tskey-api-test"],
+        mock_client,
+    )
+    assert exit_code == 0
+    assert output == snapshot
+    mock_client.update_tailnet_settings.assert_called_once_with(
+        devices_approval_on=True,
+    )
+
+
+def test_settings_key_duration_command(
+    runner: CliRunner,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Settings key-duration command prints confirmation."""
+    mock_client = _mock_tailscale()
+    exit_code, output = _invoke(
+        runner,
+        ["settings", "key-duration", "90", "--api-key", "tskey-api-test"],
+        mock_client,
+    )
+    assert exit_code == 0
+    assert output == snapshot
+    mock_client.update_tailnet_settings.assert_called_once_with(
+        devices_key_duration_days=90,
+    )
+
+
+def test_settings_external_tailnets_command(
+    runner: CliRunner,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Settings external-tailnets command prints confirmation."""
+    mock_client = _mock_tailscale()
+    exit_code, output = _invoke(
+        runner,
+        ["settings", "external-tailnets", "admin", "--api-key", "tskey-api-test"],
+        mock_client,
+    )
+    assert exit_code == 0
+    assert output == snapshot
+    mock_client.update_tailnet_settings.assert_called_once_with(
+        users_role_allowed_to_join_external_tailnets="admin",
+    )
 
 
 # --- action commands ---
@@ -674,6 +728,141 @@ def test_dump_routes_command(
     exit_code, output = _invoke(
         runner,
         ["dump", "routes", "12345", "--api-key", "tskey-api-test"],
+        mock_cls,
+    )
+    assert exit_code == 0
+    assert json.loads(output) == json.loads(raw)
+
+
+def test_dump_dns_nameservers_command(
+    runner: CliRunner,
+) -> None:
+    """Dump DNS nameservers command outputs raw JSON."""
+    raw = _load_fixture("dns_nameservers.json")
+    mock_cls = _mock_tailscale(raw_response=raw)
+    exit_code, output = _invoke(
+        runner,
+        ["dump", "dns-nameservers", "--api-key", "tskey-api-test"],
+        mock_cls,
+    )
+    assert exit_code == 0
+    assert json.loads(output) == json.loads(raw)
+
+
+def test_dump_dns_preferences_command(
+    runner: CliRunner,
+) -> None:
+    """Dump DNS preferences command outputs raw JSON."""
+    raw = _load_fixture("dns_preferences.json")
+    mock_cls = _mock_tailscale(raw_response=raw)
+    exit_code, output = _invoke(
+        runner,
+        ["dump", "dns-preferences", "--api-key", "tskey-api-test"],
+        mock_cls,
+    )
+    assert exit_code == 0
+    assert json.loads(output) == json.loads(raw)
+
+
+def test_dump_dns_search_paths_command(
+    runner: CliRunner,
+) -> None:
+    """Dump DNS search paths command outputs raw JSON."""
+    raw = _load_fixture("dns_searchpaths.json")
+    mock_cls = _mock_tailscale(raw_response=raw)
+    exit_code, output = _invoke(
+        runner,
+        ["dump", "dns-search-paths", "--api-key", "tskey-api-test"],
+        mock_cls,
+    )
+    assert exit_code == 0
+    assert json.loads(output) == json.loads(raw)
+
+
+def test_dump_dns_split_command(
+    runner: CliRunner,
+) -> None:
+    """Dump split DNS command outputs raw JSON."""
+    raw = _load_fixture("split_dns.json")
+    mock_cls = _mock_tailscale(raw_response=raw)
+    exit_code, output = _invoke(
+        runner,
+        ["dump", "dns-split", "--api-key", "tskey-api-test"],
+        mock_cls,
+    )
+    assert exit_code == 0
+    assert json.loads(output) == json.loads(raw)
+
+
+def test_dump_users_command(
+    runner: CliRunner,
+) -> None:
+    """Dump users command outputs raw JSON."""
+    raw = _load_fixture("users.json")
+    mock_cls = _mock_tailscale(raw_response=raw)
+    exit_code, output = _invoke(
+        runner,
+        ["dump", "users", "--api-key", "tskey-api-test"],
+        mock_cls,
+    )
+    assert exit_code == 0
+    assert json.loads(output) == json.loads(raw)
+
+
+def test_dump_user_command(
+    runner: CliRunner,
+) -> None:
+    """Dump user command outputs raw JSON for a single user."""
+    raw = _load_fixture("user.json")
+    mock_cls = _mock_tailscale(raw_response=raw)
+    exit_code, output = _invoke(
+        runner,
+        ["dump", "user", "u12345", "--api-key", "tskey-api-test"],
+        mock_cls,
+    )
+    assert exit_code == 0
+    assert json.loads(output) == json.loads(raw)
+
+
+def test_dump_settings_command(
+    runner: CliRunner,
+) -> None:
+    """Dump settings command outputs raw JSON."""
+    raw = _load_fixture("tailnet_settings.json")
+    mock_cls = _mock_tailscale(raw_response=raw)
+    exit_code, output = _invoke(
+        runner,
+        ["dump", "settings", "--api-key", "tskey-api-test"],
+        mock_cls,
+    )
+    assert exit_code == 0
+    assert json.loads(output) == json.loads(raw)
+
+
+def test_dump_keys_command(
+    runner: CliRunner,
+) -> None:
+    """Dump keys command outputs raw JSON."""
+    raw = _load_fixture("keys.json")
+    mock_cls = _mock_tailscale(raw_response=raw)
+    exit_code, output = _invoke(
+        runner,
+        ["dump", "keys", "--api-key", "tskey-api-test"],
+        mock_cls,
+    )
+    assert exit_code == 0
+    assert json.loads(output) == json.loads(raw)
+
+
+def test_dump_key_command(
+    runner: CliRunner,
+) -> None:
+    """Dump key command outputs raw JSON for a single key."""
+    raw = _load_fixture("key.json")
+    mock_cls = _mock_tailscale(raw_response=raw)
+    exit_code, output = _invoke(
+        runner,
+        ["dump", "key", "k1234567890abcdef", "--api-key", "tskey-api-test"],
         mock_cls,
     )
     assert exit_code == 0


### PR DESCRIPTION
# Proposed Changes

- Add missing `key.json` and `keys.json` test fixtures
- Add missing `dump keys` and `dump key` CLI commands
- Add 9 missing dump command tests (dns-*, users, user, settings, keys, key)
- Convert `settings` from single command to subcommand group with `show` + 8 update commands (device-approval, auto-updates, key-duration, user-approval, external-tailnets, network-flow-logging, regional-routing, posture-identity)
- Update README with complete CLI documentation (DNS, users, settings, keys, all dump commands)
